### PR TITLE
Transcription Viewing Bugfixes: EditorPanel position, Multiple Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ data/ecodices
 data/BnF
 data/Harvard
 build/
+bower_components/

--- a/css/mirador.css
+++ b/css/mirador.css
@@ -817,6 +817,20 @@ li.highlight {
   border-top: 1px lightgray solid;
 }
 
+.editorPanel form {
+  height: 100%;
+  overflow-y: auto;
+}
+
+.right {
+  position:absolute;
+  right:0;
+  bottom:0;
+  width:350px;
+  height:100%;
+  border-left:1px lightgray solid;
+}
+
 .editorPanel.minimized {
   transform:translateY(230px);
 }
@@ -846,22 +860,30 @@ li.highlight {
 
 .editorPanel ul.annotations {
   list-style-type: none;
-  padding:10px;
-  overflow-y: auto;
-  height: 190px;
+  padding:5px 10px;
+  /*overflow-y: auto;*/
+  /*height: 190px;*/
 }
 
 .editorPanel li.annotationItem {
   background-color: rgba(0,0,0,1);
-  margin-bottom: 10px;
-  margin-right: 20px;
-  padding: 10px;
+  /*margin-bottom: 10px;*/
+  margin-right: 10px;
+  padding: 5px;
   border-radius: 5px;
   border: 1px solid deepSkyBlue;
 }
 
 .editorPanel li.annotationItem p {
-  margin:0px;
+  margin:0 0 10px 0;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.emphasize {
+  text-decoration: underline;
 }
 
 .editorPanel .annotations li.selected {

--- a/js/src/widgets/annotationsLayer.js
+++ b/js/src/widgets/annotationsLayer.js
@@ -51,9 +51,10 @@
     filterList: function(listId){
       var _this = this;
 
-      var window = $.viewer.workspace.windows.map(function(window){
-            if(window.id == _this.windowId){ return window; }
-          });
+      var window = $.viewer.workspace.windows
+        // Return array of only those 'windows' whose ID matches the current window ID
+        .filter(function(window) { return window.id == _this.windowId; }
+      );
 
       var annos = null;
 

--- a/js/src/widgets/editorPanel.js
+++ b/js/src/widgets/editorPanel.js
@@ -15,7 +15,7 @@
             var _this = this;
 
             this.state({
-                position: 'bottom',
+                position: 'right',
                 title: 'untitled',
                 annotations: [],
                 selectedAnno: null,

--- a/js/src/widgets/editorPanel.js
+++ b/js/src/widgets/editorPanel.js
@@ -115,7 +115,7 @@
             return {
                 annotations: state.annotations,
                 selected: state.selectedAnno,
-                postion: state.position,
+                position: state.position,
                 open: state.open,
                 size:  state.size
             };

--- a/js/src/widgets/editorPanel.js
+++ b/js/src/widgets/editorPanel.js
@@ -51,9 +51,10 @@
           var _this = this,
               state = this.state();
 
-          var window = $.viewer.workspace.windows.map(function(window){
-                if(window.id == _this.windowId){ return window; }
-              });
+          var window = $.viewer.workspace.windows
+            // Return array of only those 'windows' whose ID matches the current window ID
+            .filter(function(window) { return window.id == _this.windowId; }
+          );
 
           if(listId === null){
             state.annotations = window[0].annotationsList;


### PR DESCRIPTION
- EditorPanel had previously complained when retrieving annotation lists from multiple windows in the same workspace. Should now be fixed.
- 'position' class should now actually be correctly applied to editorPanel 
